### PR TITLE
Add support for M1 macs

### DIFF
--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -78,17 +78,74 @@ jobs:
           asset_path: ${{ env.BIN }}.zip
           asset_name: ${{ env.BIN }}-${{ matrix.target }}.zip
           asset_content_type: application/zip
-
   macos:
     runs-on: macos-latest
-    needs: install-cross
     strategy:
       matrix:
         target:
           # macOS
           - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+
+      # Cache files between builds
+      - name: Setup | Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+
+      - name: Build | Build
+        uses: actions-rs/cargo@v1
+        # TODO: Remove this once it's the default
+        env:
+          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
+          use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - run: tar -czvf ${{ env.BIN }}.tar.gz --directory=target/${{ matrix.target }}/release ${{ env.BIN }}
+      - uses: XAMPPRocky/create-release@v1.0.2
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - uses: actions/upload-release-asset@v1
+        id: upload-release-asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.BIN }}.tar.gz
+          asset_name: ${{ env.BIN }}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip
+
+  ios:
+    runs-on: macos-latest
+    needs: install-cross
+    strategy:
+      matrix:
+        target:
           # iOS
-          # - aarch64-apple-ios
+          - aarch64-apple-ios
           # - armv7-apple-ios
           # - armv7s-apple-ios
           # - i386-apple-ios


### PR DESCRIPTION
This will build MacOS binary without cross. Added another section to build iOS binaries using cross.

Copied from: https://github.com/starship/starship/blob/master/.github/workflows/deploy.yml

Tested on this repo: https://github.com/avencera/rustywind/releases